### PR TITLE
Fix double release when closing side window

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -43,6 +43,7 @@ class SideFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
     self.makeKeyAndOrderFront(nil)
     self.title = String(format: "Flutter Window #%llu", windowId())
+    self.isReleasedWhenClosed = false
 
     self.setFrameTopLeftPoint(windowOrigin(viewId: windowId()))
   }


### PR DESCRIPTION
`isReleasedWhenClosed` is `YES` by default for historical reason, but it needs to be set to `NO` with ARC, otherwise there is an extra `autorelease` call when closing window causing crash.