### PR TITLE
Prototype new macOS app runner

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -7,14 +7,22 @@ import FlutterMacOS
 
 @NSApplicationMain
 class AppDelegate: FlutterAppDelegate {
+  lazy var flutterEngine = FlutterEngine(name: "io.flutter", project: nil, allowHeadlessExecution: true)
+
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }
 
   override func applicationDidFinishLaunching(_ aNotification: Notification) {
-    let newWindow = SideFlutterWindow(engine: MainFlutterWindow.engine!)
+    flutterEngine.run(withEntrypoint: nil)
+    RegisterGeneratedPlugins(registry: self.flutterEngine)
+
+    let mainWindow = self.mainFlutterWindow as! MainFlutterWindow
+    mainWindow.showFlutter(engine: flutterEngine)
+
+    let newWindow = SideFlutterWindow(engine: self.flutterEngine)
     DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
-      let newWindow = SideFlutterWindow(engine: MainFlutterWindow.engine!)
+      let newWindow = SideFlutterWindow(engine: self.flutterEngine)
     }
   }
 }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -14,18 +14,12 @@ func windowOrigin(viewId: Int64) -> CGPoint {
 }
 
 class MainFlutterWindow: NSWindow {
-  static var engine: FlutterEngine?
-
-  override func awakeFromNib() {
-    super.awakeFromNib()
-    let flutterViewController = FlutterViewController()
-    MainFlutterWindow.engine = flutterViewController.engine;
+  func showFlutter(engine: FlutterEngine) {
+    let flutterViewController = FlutterViewController(engine: engine, nibName: nil, bundle: nil)
     let windowFrame = self.frame
+
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
-
-    RegisterGeneratedPlugins(registry: flutterViewController)
-
     self.setFrameTopLeftPoint(windowOrigin(viewId: 0))
   }
 }


### PR DESCRIPTION
This is a quick and dirty prototype for a multi-window app runner. The goals are:

1. You can create a headless engine without a view controller
2. You can register plugins on that headless engine
3. You can attach arbitrary view controllers to the engine

These changes aren't necessary for phase 1 (multi-view). However, it approximates the runner needed for phase 2 (multi-window where the Dart app creates the initial window) to verify the APIs are acceptable.

⚠️ TODO: One piece that's not covered here is how to distinguish the implicit view from regular views. I'll need to experiment with that.

<details>
<summary>Last time I did Apple development was over a decade ago, no judging!</summary>

![image](https://github.com/goderbauer/mvp/assets/737941/3001139e-2f43-428b-85ff-27cbf23ee635)

</details>