### PR TITLE
[web] Make sure the multi-view container fills the page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -38,9 +38,14 @@
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
+  <style>
+    body {
+      margin: 0;
+    }
+  </style>
 </head>
 <body>
-  <div style="width: 100%; height: 100%;">
+  <div style="width: 100%; height: 100%; position: absolute;">
     <div id="left" style="width: 50%; height: 100%; float: left;"></div>
     <div id="right" style="width: 50%; height: 100%; float: left;"></div>
   </div>


### PR DESCRIPTION
When the implicit view is disabled ([PR](https://github.com/flutter/engine/pull/48505)), the multi-view container has a height of 0 (don't ask me, ask CSS).

This PR makes sure that the multi-view container can fill the page on its own without needing the side effect of the implicit view to do so.