### PR TITLE
Use runWidget; remove runAppWithoutImplicitView

### DIFF
--- a/lib/raw_dynamic.dart
+++ b/lib/raw_dynamic.dart
@@ -28,7 +28,7 @@ void _handleOnMetricsChanged() {
 void _handleOnBeginFrame(Duration timeStamp) {
   for (final FlutterView view in PlatformDispatcher.instance.views) {
     final Size logicalSize = view.physicalSize / view.devicePixelRatio;
-    final Color color = _colors[(view.viewId as int) % _colors.length];
+    final Color color = _colors[view.viewId % _colors.length];
 
     final ParagraphBuilder paragraphBuilder = ParagraphBuilder(
       ParagraphStyle(textDirection: TextDirection.ltr, fontSize: 24),

--- a/lib/raw_static.dart
+++ b/lib/raw_static.dart
@@ -31,7 +31,7 @@ void _handleOnDrawFrame() {
 
   for (final FlutterView view in PlatformDispatcher.instance.views) {
     final Size logicalSize = view.physicalSize / view.devicePixelRatio;
-    final Color color = _colors[(view.viewId as int) % _colors.length];
+    final Color color = _colors[view.viewId % _colors.length];
 
     final ParagraphBuilder paragraphBuilder = ParagraphBuilder(
       ParagraphStyle(textDirection: TextDirection.ltr, fontSize: 24),

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -71,15 +71,3 @@ class _MultiViewAppState extends State<MultiViewApp> with WidgetsBindingObserver
     return ViewCollection(views: _views.values.toList(growable: false));
   }
 }
-
-// TODO(goderbauer): Add this to the framework.
-/// This is like [runApp] but without a call to
-/// [WidgetsBinding.wrapWithDefaultView]. The provided `app` must instantiate
-/// [View] widgets where necessary.
-void runAppWithoutImplicitView(Widget app) {
-  final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
-  assert(binding.debugCheckZone('runApp'));
-  binding
-    ..scheduleAttachRootWidget(app) // ignore: invalid_use_of_protected_member
-    ..scheduleWarmUpFrame();
-}

--- a/lib/widgets_counter.dart
+++ b/lib/widgets_counter.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'src/widgets.dart';
 
 void main() {
-  runAppWithoutImplicitView(MultiViewApp(
+  runWidget(MultiViewApp(
     viewBuilder: (BuildContext context) => const Counter(),
   ));
 }

--- a/lib/widgets_dynamic.dart
+++ b/lib/widgets_dynamic.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'src/widgets.dart';
 
 void main() {
-  runAppWithoutImplicitView(MultiViewApp(
+  runWidget(MultiViewApp(
     viewBuilder: (BuildContext context) => const SpinningSquare(),
   ));
 }
@@ -32,7 +32,7 @@ class _SpinningSquareState extends State<SpinningSquare> with SingleTickerProvid
 
   @override
   Widget build(BuildContext context) {
-    final int viewId = View.of(context).viewId as int;
+    final int viewId = View.of(context).viewId;
     return Directionality(
       textDirection: TextDirection.ltr,
       child: Center(

--- a/lib/widgets_static.dart
+++ b/lib/widgets_static.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'src/widgets.dart';
 
 void main() {
-  runAppWithoutImplicitView(MultiViewApp(
+  runWidget(MultiViewApp(
     viewBuilder: (BuildContext context) => const HelloWorld(),
   ));
 }


### PR DESCRIPTION
`runWidget` is now part of the framework and replaces the local `runAppWithoutImplicitView` helper.

Also cleans up some outdated casts.

**DO NOT SUBMIT UNTIL https://github.com/flutter/flutter/pull/141484 HAS LANDED.**