### PR TITLE
Switch playground to engine patch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The demos in this repository run on the following platforms:
 | Platform | Support                                               |
 |----------|-------------------------------------------------------|
 | macOS    | ⚠️ with custom engine branch (see instructions below) |
-| Windows  | ⚠️ with custom engine branch (see instructions below) |
+| Windows  | ⚠️ with engine patch (see instructions below)         |
 | Linux    | ❌                                                    |
 | Web      | ✅   (`flutter run -d chrome`)                        |
 
@@ -36,11 +36,9 @@ git checkout master
 
 2. Set up the Engine development environment: See [the wiki page](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment).
 
-3. In **the engine repo**, add the prototype remote and switch to the prototype branch:
+3. In **the engine repo**, apply this playground's patches:
 ```
-git remote add dkwingsmt https://github.com/dkwingsmt/engine/
-git fetch dkwingsmt fffa6e19f5b71bedd55ac3a7fa6acfd85eda5983
-git checkout fffa6e19f5b71bedd55ac3a7fa6acfd85eda5983
+git apply /path/to/playground/patches/001-Add-multi-view-Flutter-Windows-C++-APIs.patch
 ```
 
 4. In **this repo**, edit `pubspec.yaml`, and add the following dependency override to use the custom `dart:ui` library:

--- a/README.md
+++ b/README.md
@@ -36,16 +36,9 @@ git checkout master
 
 2. Set up the Engine development environment: See [the wiki page](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment).
 
-3. In **the engine repo**, apply this playground's patches:
+3. Windows only: in **the engine repo**, apply this playground's patch:
 ```
 git apply /path/to/playground/patches/001-Add-multi-view-Flutter-Windows-C++-APIs.patch
-```
-
-4. In **this repo**, edit `pubspec.yaml`, and add the following dependency override to use the custom `dart:ui` library:
-```
-dependency_overrides:
-  sky_engine:
-    path: /path/to/flutter/engine/out/host_debug_unopt/gen/dart-pkg/sky_engine
 ```
 
 5. Build the custom engine: See [the wiki page](https://github.com/flutter/flutter/wiki/Compiling-the-engine#compiling-for-macos-or-linux).

--- a/patches/001-Add-multi-view-Flutter-Windows-C++-APIs.patch
+++ b/patches/001-Add-multi-view-Flutter-Windows-C++-APIs.patch
@@ -1,0 +1,293 @@
+From 051ecbb99bc410ed71708386f5cd6c6c6afcfd95 Mon Sep 17 00:00:00 2001
+From: Loic Sharma <sharma.loic@gmail.com>
+Date: Tue, 16 Apr 2024 13:16:28 -0700
+Subject: [PATCH] Add multi-view Flutter Windows C++ APIs
+
+Updates `FlutterViewController` and allows creating multiple windows on Windows:
+
+1. It makes the `FlutterDesktopEngineCreateViewController` C API public
+2. It makes the `FlutterViewController` no longer take ownership of the `FlutterDesktopEngineRef` (by switching to the `FlutterDesktopEngineCreateViewController` C API instead of `FlutterDesktopViewControllerCreate` C API).
+3. It adds a new `FlutterViewController` constructor that accepts an engine, thereby allowing to have multiple views on the same engine.
+---
+ .../windows/client_wrapper/flutter_engine.cc  |  5 ++--
+ .../client_wrapper/flutter_view_controller.cc | 27 +++++++++++++++++--
+ .../flutter_view_controller_unittests.cc      | 14 +++++-----
+ .../include/flutter/flutter_engine.h          | 10 ++-----
+ .../include/flutter/flutter_view_controller.h | 13 +++++++++
+ .../testing/stub_flutter_windows_api.cc       |  9 +++++++
+ .../testing/stub_flutter_windows_api.h        |  6 +++++
+ .../windows/flutter_windows_internal.h        | 25 -----------------
+ .../platform/windows/public/flutter_windows.h | 25 +++++++++++++++++
+ 9 files changed, 89 insertions(+), 45 deletions(-)
+
+diff --git a/shell/platform/windows/client_wrapper/flutter_engine.cc b/shell/platform/windows/client_wrapper/flutter_engine.cc
+index 7860947aa068b..3cbe59622fc4f 100644
+--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
++++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
+@@ -63,7 +63,7 @@ bool FlutterEngine::Run(const char* entry_point) {
+ }
+ 
+ void FlutterEngine::ShutDown() {
+-  if (engine_ && owns_engine_) {
++  if (engine_) {
+     FlutterDesktopEngineDestroy(engine_);
+   }
+   engine_ = nullptr;
+@@ -113,8 +113,7 @@ std::optional<LRESULT> FlutterEngine::ProcessExternalWindowMessage(
+   return std::nullopt;
+ }
+ 
+-FlutterDesktopEngineRef FlutterEngine::RelinquishEngine() {
+-  owns_engine_ = false;
++FlutterDesktopEngineRef FlutterEngine::engine() const {
+   return engine_;
+ }
+ 
+diff --git a/shell/platform/windows/client_wrapper/flutter_view_controller.cc b/shell/platform/windows/client_wrapper/flutter_view_controller.cc
+index 98c65e10c27bc..1c1b51ee753c0 100644
+--- a/shell/platform/windows/client_wrapper/flutter_view_controller.cc
++++ b/shell/platform/windows/client_wrapper/flutter_view_controller.cc
+@@ -12,9 +12,32 @@ namespace flutter {
+ FlutterViewController::FlutterViewController(int width,
+                                              int height,
+                                              const DartProject& project) {
++  FlutterDesktopViewControllerProperties properties = {};
++  properties.width = width;
++  properties.height = height;
++
+   engine_ = std::make_shared<FlutterEngine>(project);
+-  controller_ = FlutterDesktopViewControllerCreate(width, height,
+-                                                   engine_->RelinquishEngine());
++  controller_ =
++      FlutterDesktopEngineCreateViewController(engine_->engine(), &properties);
++  if (!controller_) {
++    std::cerr << "Failed to create view controller." << std::endl;
++    return;
++  }
++  view_ = std::make_unique<FlutterView>(
++      FlutterDesktopViewControllerGetView(controller_));
++}
++
++FlutterViewController::FlutterViewController(
++    int width,
++    int height,
++    std::shared_ptr<FlutterEngine> engine) {
++  FlutterDesktopViewControllerProperties properties = {};
++  properties.width = width;
++  properties.height = height;
++
++  engine_ = std::move(engine);
++  controller_ =
++      FlutterDesktopEngineCreateViewController(engine_->engine(), &properties);
+   if (!controller_) {
+     std::cerr << "Failed to create view controller." << std::endl;
+     return;
+diff --git a/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc b/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
+index 837c2e13e583d..f79842f280978 100644
+--- a/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
++++ b/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
+@@ -17,10 +17,8 @@ namespace {
+ class TestWindowsApi : public testing::StubFlutterWindowsApi {
+  public:
+   // |flutter::testing::StubFlutterWindowsApi|
+-  FlutterDesktopViewControllerRef ViewControllerCreate(
+-      int width,
+-      int height,
+-      FlutterDesktopEngineRef engine) override {
++  FlutterDesktopViewControllerRef EngineCreateViewController(
++      const FlutterDesktopViewControllerProperties* properties) override {
+     return reinterpret_cast<FlutterDesktopViewControllerRef>(2);
+   }
+ 
+@@ -63,11 +61,13 @@ TEST(FlutterViewControllerTest, CreateDestroy) {
+   testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+       std::make_unique<TestWindowsApi>());
+   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
++
++  // Create and destroy a view controller.
++  // This should also create and destroy an engine.
+   { FlutterViewController controller(100, 100, project); }
++
+   EXPECT_TRUE(test_api->view_controller_destroyed());
+-  // Per the C API, once a view controller has taken ownership of an engine
+-  // the engine destruction method should not be called.
+-  EXPECT_FALSE(test_api->engine_destroyed());
++  EXPECT_TRUE(test_api->engine_destroyed());
+ }
+ 
+ TEST(FlutterViewControllerTest, GetViewId) {
+diff --git a/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h b/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
+index 0369db35a14fc..89ca2d188b46f 100644
+--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
++++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
+@@ -98,11 +98,8 @@ class FlutterEngine : public PluginRegistry {
+   // For access to the engine handle.
+   friend class FlutterViewController;
+ 
+-  // Gives up ownership of |engine_|, but keeps a weak reference to it.
+-  //
+-  // This is intended to be used by FlutterViewController, since the underlying
+-  // C API for view controllers takes over engine ownership.
+-  FlutterDesktopEngineRef RelinquishEngine();
++  // Get the handle for interacting with the C API's engine reference.
++  FlutterDesktopEngineRef engine() const;
+ 
+   // Handle for interacting with the C API's engine reference.
+   FlutterDesktopEngineRef engine_ = nullptr;
+@@ -110,9 +107,6 @@ class FlutterEngine : public PluginRegistry {
+   // Messenger for communicating with the engine.
+   std::unique_ptr<BinaryMessenger> messenger_;
+ 
+-  // Whether or not this wrapper owns |engine_|.
+-  bool owns_engine_ = true;
+-
+   // Whether |Run| has been called successfully.
+   //
+   // This is used to improve error messages. This can be false while the engine
+diff --git a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+index 4007534a5d73e..b26e017a6760a 100644
+--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
++++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+@@ -32,6 +32,16 @@ class FlutterViewController {
+   // |dart_project| will be used to configure the engine backing this view.
+   FlutterViewController(int width, int height, const DartProject& project);
+ 
++  // Creates a FlutterView that can be parented into a Windows View hierarchy
++  // either using HWNDs.
++  //
++  // This creates the view on an existing FlutterEngine.
++  //
++  // |dart_project| will be used to configure the engine backing this view.
++  FlutterViewController(int width,
++                        int height,
++                        std::shared_ptr<FlutterEngine> engine);
++
+   virtual ~FlutterViewController();
+ 
+   // Prevent copying.
+@@ -44,6 +54,9 @@ class FlutterViewController {
+   // Returns the engine running Flutter content in this view.
+   FlutterEngine* engine() const { return engine_.get(); }
+ 
++  // Returns the engine running Flutter content in this view.
++  std::shared_ptr<FlutterEngine> shared_engine() const { return engine_; }
++
+   // Returns the view managed by this controller.
+   FlutterView* view() const { return view_.get(); }
+ 
+diff --git a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+index f51d7f14ad879..67582e1f0f0cc 100644
+--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
++++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+@@ -114,6 +114,15 @@ bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,
+   return true;
+ }
+ 
++FlutterDesktopViewControllerRef FlutterDesktopEngineCreateViewController(
++    FlutterDesktopEngineRef engine,
++    const FlutterDesktopViewControllerProperties* properties) {
++  if (s_stub_implementation) {
++    return s_stub_implementation->EngineCreateViewController(properties);
++  }
++  return nullptr;
++}
++
+ uint64_t FlutterDesktopEngineProcessMessages(FlutterDesktopEngineRef engine) {
+   if (s_stub_implementation) {
+     return s_stub_implementation->EngineProcessMessages();
+diff --git a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+index 8f3eb0905ac7a..754c3da8a9970 100644
+--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
++++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+@@ -63,6 +63,12 @@ class StubFlutterWindowsApi {
+   // Called for FlutterDesktopEngineRun.
+   virtual bool EngineRun(const char* entry_point) { return true; }
+ 
++  // Called for FlutterDesktopEngineCreateViewController.
++  virtual FlutterDesktopViewControllerRef EngineCreateViewController(
++      const FlutterDesktopViewControllerProperties* properties) {
++    return nullptr;
++  }
++
+   // Called for FlutterDesktopEngineProcessMessages.
+   virtual uint64_t EngineProcessMessages() { return 0; }
+ 
+diff --git a/shell/platform/windows/flutter_windows_internal.h b/shell/platform/windows/flutter_windows_internal.h
+index bb1e6f767905f..47b98e983a48a 100644
+--- a/shell/platform/windows/flutter_windows_internal.h
++++ b/shell/platform/windows/flutter_windows_internal.h
+@@ -14,31 +14,6 @@ extern "C" {
+ // Declare functions that are currently in-progress and shall be exposed to the
+ // public facing API upon completion.
+ 
+-// Properties for configuring a Flutter view controller.
+-typedef struct {
+-  // The view's initial width.
+-  int width;
+-
+-  // The view's initial height.
+-  int height;
+-} FlutterDesktopViewControllerProperties;
+-
+-// Creates a view for the given engine.
+-//
+-// The |engine| will be started if it is not already running.
+-//
+-// The caller owns the returned reference, and is responsible for calling
+-// |FlutterDesktopViewControllerDestroy|. Returns a null pointer in the event of
+-// an error.
+-//
+-// Unlike |FlutterDesktopViewControllerCreate|, this does *not* take ownership
+-// of |engine| and |FlutterDesktopEngineDestroy| must be called to destroy
+-// the engine.
+-FLUTTER_EXPORT FlutterDesktopViewControllerRef
+-FlutterDesktopEngineCreateViewController(
+-    FlutterDesktopEngineRef engine,
+-    const FlutterDesktopViewControllerProperties* properties);
+-
+ typedef int64_t PlatformViewId;
+ 
+ typedef struct {
+diff --git a/shell/platform/windows/public/flutter_windows.h b/shell/platform/windows/public/flutter_windows.h
+index 80d78766f9383..d7b2a30520b04 100644
+--- a/shell/platform/windows/public/flutter_windows.h
++++ b/shell/platform/windows/public/flutter_windows.h
+@@ -70,6 +70,15 @@ typedef struct {
+ 
+ } FlutterDesktopEngineProperties;
+ 
++// Properties for configuring a Flutter view controller.
++typedef struct {
++  // The view's initial width.
++  int width;
++
++  // The view's initial height.
++  int height;
++} FlutterDesktopViewControllerProperties;
++
+ // ========== View Controller ==========
+ 
+ // Creates a view that hosts and displays the given engine instance.
+@@ -165,6 +174,22 @@ FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
+ FLUTTER_EXPORT bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,
+                                             const char* entry_point);
+ 
++// Creates a view for the given engine.
++//
++// The |engine| will be started if it is not already running.
++//
++// The caller owns the returned reference, and is responsible for calling
++// |FlutterDesktopViewControllerDestroy|. Returns a null pointer in the event of
++// an error.
++//
++// Unlike |FlutterDesktopViewControllerCreate|, this does *not* take ownership
++// of |engine| and |FlutterDesktopEngineDestroy| must be called to destroy
++// the engine.
++FLUTTER_EXPORT FlutterDesktopViewControllerRef
++FlutterDesktopEngineCreateViewController(
++    FlutterDesktopEngineRef engine,
++    const FlutterDesktopViewControllerProperties* properties);
++
+ // DEPRECATED: This is no longer necessary to call, Flutter will take care of
+ // processing engine messages transparently through DispatchMessage.
+ //


### PR DESCRIPTION
Updates the playground to use patch files instead of an engine fork.

The `patches/001-Add-multi-view-Flutter-Windows-C++-APIs.patch` patch file updates the Flutter Windows `FlutterViewController` and allows creating multiple windows on Windows. See: https://github.com/flutter/flutter/issues/143767#issuecomment-2050741185